### PR TITLE
coffee-file: Changed name from MX8MM to i.MX8M Mini

### DIFF
--- a/kontron-mx8mm.coffee
+++ b/kontron-mx8mm.coffee
@@ -4,8 +4,8 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 module.exports =
 	version: 1
 	slug: 'kontron-mx8mm'
-	aliases: [ 'kontron-mx8mm' ]
-	name: 'Kontron MX8MM'
+	aliases: [ ]
+	name: 'Kontron i.MX8M Mini'
 	arch: 'aarch64'
 	state: 'released'
 	isDefault: true


### PR DESCRIPTION
In the kontron-mx8mm.coffee file changed the module.exports name to i.MX8M Mini and removed the alias.

Changelog-entry: Changed name in coffee file from MX8MM to i.MX8M Mini
Signed-off-by: joris-bright <joris@bright-energy.eu>