### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-kontron/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-kontron/recipes-core/images/balena-image.inc
@@ -7,3 +7,7 @@ BALENA_BOOT_PARTITION_FILES:append:kontron-mx8mm = " \
 IMAGE_CMD:balenaos-img:append () {
     dd if=${DEPLOY_DIR_IMAGE}/flash.bin of=${BALENA_RAW_IMG} conv=notrunc seek=33 bs=1K
 }
+
+IMAGE_ROOTFS_SIZE:kontron-mx8mm = "327680"
+BALENA_BOOT_SIZE:kontron-mx8mm = "40960"
+BALENA_STATE_SIZE:kontron-mx8mm = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.